### PR TITLE
Changed gentoo package name in instructions to app-misc/openrazer

### DIFF
--- a/index.html
+++ b/index.html
@@ -422,7 +422,7 @@ layout: null
                     <p>To add and install:</p>
 <pre><code><span class="fa fa-dollar"></span> eselect repository enable vifino-overlay</code>
 <code><span class="fa fa-dollar"></span> emaint sync -r vifino-overlay</code>
-<code><span class="fa fa-dollar"></span> emerge sys-apps/openrazer</code></pre>
+<code><span class="fa fa-dollar"></span> emerge app-misc/openrazer</code></pre>
                     <p>After the drivers are installed, please restart the computer.</p>
                   </div>
                 </div>


### PR DESCRIPTION
I saw gentoo's instructions were updated in [this commit](https://github.com/openrazer/openrazer.github.io/commit/9513ec52a36a0007d6da972c5862a34f677d8c93), but it used wrong package name which won't work for users trying to install