### PR TITLE
Remove extraneous python.withPackages nixos command

### DIFF
--- a/index.html
+++ b/index.html
@@ -467,11 +467,7 @@ layout: null
                     <p>Rebuild your NixOS configuration:</p>
                     <pre><code><span class="fa fa-dollar"></span> sudo nixos-rebuild switch</code></pre>
                     <h4>nix-shell</h4>
-                    <p>Following the example provided by python section of the nixpkgs <a
-                        href="https://nixos.org/nixpkgs/manual/#temporary-python-environment-with-nix-shell">documentation</a>,
-                      here is one way to launch a <code>nix-shell</code> with the dependencies for OpenRazer, using
-                      <code>python3.7</code>:</p>
-                    <pre><code><span class="fa fa-dollar"></span> nix-shell -p 'python37.withPackages(ps: with ps; [ openrazer ])' -p openrazer-daemon</code></pre>
+                    <pre><code><span class="fa fa-dollar"></span> nix-shell -p openrazer-daemon</code></pre>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
openrazer-daemon is exported as a top-level package, so we dont' need to bring in python packages

```
[13:33:58] jon@jon-desktop /home/jon/projects/openrazer.github.io (cleanup-nixos)
$ nix-shell -p openrazer-daemon --pure

[nix-shell:/home/jon/projects/openrazer.github.io]$ openrazer-daemon --help
usage: .openrazer-daemon-wrapped [-h] [-v] [-F] [-r] [-s] [--version] [--as-root] [--config CONFIG]
                                 [--persistence PERSISTENCE] [--run-dir RUN_DIR] [--log-dir LOG_DIR] [--test-dir TEST_DIR]

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Enable verbose logging
  -F, --foreground      Don't fork stay in the foreground
  -r, --respawn         Stop any existing daemon first, if one is running.
  -s, --stop            Gracefully stop the existing daemon.
  --version             show program's version number and exit
  --as-root             Allow the daemon to be started as root
  --config CONFIG       Location of the config file
  --persistence PERSISTENCE
                        Location to file for storing device persistence data
  --run-dir RUN_DIR     Location of the run directory
  --log-dir LOG_DIR     Location of the log directory
  --test-dir TEST_DIR   Directory containing test driver structure
  ```
  
  The `--pure` here is just to show it's not being inherited from an outer scope