### PR TITLE
Deathadder 2000 icon loads through https

### DIFF
--- a/_data/devices.yml
+++ b/_data/devices.yml
@@ -454,7 +454,7 @@
 
 - name: "DeathAdder 2000"
   type: "mouse"
-  image_url: "https://cn.razerzone.com/assets/product/gallery/deathadder-2000-gallery-1.png"
+  image_url: "https://assets2.razerzone.com/images/da10m/carousel/razer-death-adder-gallery-09.png"
   vid: "1532"
   pid: "004F"
 

--- a/_data/devices.yml
+++ b/_data/devices.yml
@@ -454,7 +454,7 @@
 
 - name: "DeathAdder 2000"
   type: "mouse"
-  image_url: "http://cn.razerzone.com/assets/product/gallery/deathadder-2000-gallery-1.png"
+  image_url: "https://cn.razerzone.com/assets/product/gallery/deathadder-2000-gallery-1.png"
   vid: "1532"
   pid: "004F"
 


### PR DESCRIPTION
The deathadder 2000 icon gets loaded through http. Viewing openrazer.github.io over https doesn't show the icon properly.
This PR fixes this issue.
![](https://ninjamar.dev/assets/images/openrazerfnferr.png)