### PR TITLE
Store a Fedora version of hardware:razer.repo

### DIFF
--- a/index.md
+++ b/index.md
@@ -122,7 +122,7 @@ instructions:
 
             For Fedora 41 (and later), run the following:
 
-                sudo dnf config-manager addrepo --from-repofile=https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo
+                sudo dnf config-manager addrepo --from-repofile=https://openrazer.github.io/hardware:razer.repo
 
                 sudo dnf install openrazer-meta
 
@@ -134,7 +134,7 @@ instructions:
 
             For Fedora 40 (and earlier), run the following:
 
-                sudo dnf config-manager --add-repo https://download.opensuse.org/repositories/hardware:/razer/Fedora_$(rpm -E %fedora)/hardware:razer.repo
+                sudo dnf config-manager --add-repo https://openrazer.github.io/hardware:razer.repo
 
                 sudo dnf install openrazer-meta
 

--- a/misc/hardware_razer.repo
+++ b/misc/hardware_razer.repo
@@ -1,0 +1,10 @@
+---
+permalink: /hardware:razer.repo
+---
+[hardware_razer]
+name=Fedora $releasever - hardware:razer
+type=rpm-md
+baseurl=https://download.opensuse.org/repositories/hardware:/razer/Fedora_$releasever/
+gpgcheck=1
+gpgkey=https://download.opensuse.org/repositories/hardware:/razer/Fedora_$releasever/repodata/repomd.xml.key
+enabled=1


### PR DESCRIPTION
This uses the `Fedora_$releasever` variable so the user is always pointed to the correct release repository for their Fedora version.

Works for: Fedora 39, 40, 41

Does not work: Rawhide
    (The URL request is lowercase, could be a suggestion for OpenSUSE Build Service)

    Status code: 404 for https://download.opensuse.org/repositories/hardware:/razer/Fedora_rawhide/repodata/repomd.xml

Since the command to add repo changed in Fedora 41, we'll need to keep the two for now until Fedora 40 is obsolete.

Closes https://github.com/openrazer/openrazer/issues/1981