### PR TITLE
Add "Complementary" subsection under the "Applications" section

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -207,6 +207,27 @@
                             {% endfor %}
                         </div>
                     </div>
+
+                    {% if page.apps.complementary %}
+                        <h3>Complementary</h3>
+                        <p>{{ page.apps.complementary_intro }}</p>
+                        <div class="row-fluid">
+                            <div class="row features-grid apps">
+                                {% for app in page.apps.complementary %}
+                                    <div class="feature">
+                                        <a href="{{ app.url }}">
+                                            {% if app.logo contains "fa " %}
+                                                <span class="{{ app.logo }} fa-3x"></span>
+                                            {% else %}
+                                                <img src="{{ app.logo }}"/>
+                                            {% endif %}
+                                            <h4>{{ app.name }}</h4>
+                                        </a>
+                                    </div>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    {% endif %}
                 </div>
             </div>
 

--- a/css/openrazer.css
+++ b/css/openrazer.css
@@ -448,6 +448,10 @@ footer p em {
 /****************************
  * Misc.
 *****************************/
+.section .row-fluid + h3 {
+    margin-top: 32px;
+}
+
 .danger > h5 {
     padding-top: 8px;
     padding-bottom: 8px;

--- a/img/apps/input-remapper.svg
+++ b/img/apps/input-remapper.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="140.02217mm"
+   height="140.02217mm"
+   viewBox="0 0 140.02217 140.02217"
+   version="1.1"
+   id="svg2873"
+   inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)"
+   sodipodi:docname="input-remapper.svg">
+  <defs
+     id="defs2867">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       inkscape:label="Drop Shadow"
+       id="filter3282">
+      <feFlood
+         flood-opacity="0.0627451"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood3272" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="out"
+         result="composite1"
+         id="feComposite3274" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="0"
+         result="blur"
+         id="feGaussianBlur3276" />
+      <feOffset
+         dx="0"
+         dy="6"
+         result="offset"
+         id="feOffset3278" />
+      <feComposite
+         in="offset"
+         in2="SourceGraphic"
+         operator="atop"
+         result="composite2"
+         id="feComposite3280" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.35"
+     inkscape:cx="5.7814459"
+     inkscape:cy="200.68556"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:window-width="1496"
+     inkscape:window-height="1026"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0" />
+  <metadata
+     id="metadata2870">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-186.12124,-30.970871)">
+    <circle
+       style="fill:#91e5ff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.563565;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3680"
+       cx="256.13232"
+       cy="100.98196"
+       r="70.011086" />
+    <ellipse
+       style="fill:#ee628b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.785;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3702"
+       cx="288.20602"
+       cy="73.664757"
+       rx="6.8933477"
+       ry="6.9164343" />
+    <path
+       id="rect3031-2-3-7"
+       style="fill:#005a76;fill-opacity:1;stroke:none;stroke-width:1.32;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 246.78244,39.06353 c -13.52131,-2.982819 -26.90643,5.56451 -29.88928,19.08579 -2.98283,13.521297 5.56399,26.906347 19.08529,29.889177 8.59826,1.89679 17.14091,-0.86975 22.98921,-6.61198 l 15.70412,3.46437 c 2.88958,7.66978 9.4749,13.77363 18.07313,15.670423 13.52131,2.98283 26.90634,-5.564003 29.88917,-19.085303 2.99457,-13.57452 -5.56387,-26.906836 -19.08518,-29.889666 -0.1188,-0.0262 -0.2375,-0.0493 -0.35634,-0.0735 l -56.05594,-12.36605 c -0.11796,-0.0281 -0.23539,-0.0571 -0.35418,-0.0833 z m -4.14449,9.624251 3.47737,0.76712 c 0.78935,0.17413 1.41008,0.75954 1.70501,1.38489 0.29492,0.62534 0.34002,1.30234 0.19612,1.95468 l -0.012,5.997289 5.44569,2.512367 c 0.60658,0.27984 1.24614,0.46749 1.68936,0.99813 0.44322,0.53064 0.71492,1.34045 0.54079,2.12982 l -0.76712,3.47738 c -0.17414,0.78938 -0.76133,1.40969 -1.38667,1.7046 -0.62534,0.29494 -1.30055,0.34043 -1.9529,0.19652 l -5.99729,-0.012 -2.51198,5.44391 c -0.27989,0.60658 -0.46966,1.24754 -1.0003,1.69075 -0.53066,0.44322 -1.34045,0.71494 -2.12983,0.5408 l -3.47737,-0.76712 c -0.78937,-0.17414 -1.40969,-0.76133 -1.70461,-1.38668 -0.29493,-0.62532 -0.33825,-1.30192 -0.19433,-1.95429 l 0.0116,-5.9955 -5.4457,-2.51238 c -0.60659,-0.27985 -1.24751,-0.46964 -1.69074,-1.00031 -0.44321,-0.53065 -0.71315,-1.34006 -0.53901,-2.12941 l 0.76712,-3.477377 c 0.17413,-0.78935 0.75954,-1.41007 1.38489,-1.705 0.62535,-0.29494 1.30194,-0.33825 1.95429,-0.19434 l 5.99728,0.012 2.51237,-5.44569 c 0.27986,-0.60659 0.46788,-1.24793 0.99853,-1.69115 0.53066,-0.44321 1.34006,-0.71313 2.12942,-0.539 z m 59.22867,11.48398 c 3.01832,0.66585 4.93009,3.659856 4.26425,6.678156 -0.66585,3.01833 -3.65985,4.9301 -6.67818,4.26425 -3.0183,-0.66584 -4.9301,-3.65984 -4.26425,-6.67817 0.66585,-3.01831 3.65987,-4.930087 6.67818,-4.264236 z m -12.57208,8.127856 c 3.01825,0.66584 4.9302,3.65937 4.26436,6.67767 -0.66585,3.01833 -3.65986,4.93011 -6.67818,4.26426 -3.01831,-0.66585 -4.93009,-3.65986 -4.26424,-6.67818 0.66584,-3.0183 3.65981,-4.92958 6.67806,-4.26375 z m 20.55766,4.53507 c 3.01824,0.66583 4.93021,3.65937 4.26436,6.67767 -0.66585,3.01833 -3.65987,4.9301 -6.67818,4.26426 -3.01832,-0.66585 -4.93009,-3.65986 -4.26423,-6.67819 0.66584,-3.0183 3.65979,-4.92958 6.67805,-4.26374 z m -12.47553,7.96607 c 3.01824,0.66583 4.93021,3.65937 4.26436,6.67768 -0.66584,3.01829 -3.65986,4.93008 -6.67817,4.26424 -3.0183,-0.66584 -4.9301,-3.65987 -4.26425,-6.67816 0.66584,-3.01831 3.65983,-4.92959 6.67806,-4.26376 z"
+       sodipodi:nodetypes="sssccsssccssssscsssssscsssssscsssssscsssssssssssssssssssssss" />
+    <ellipse
+       style="fill:#005a76;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.785;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3704"
+       cx="236.98087"
+       cy="112.9699"
+       rx="9.4729681"
+       ry="8.2166691" />
+    <path
+       id="path1873-2-8"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ee628b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.991703;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+       d="m 223.97865,101.80893 c -1.54187,0.34009 -2.51626,1.86599 -2.17614,3.40786 l 4.49425,20.37466 c 0.34009,1.54187 1.86586,2.51573 3.40773,2.17562 l 20.37466,-4.49423 c 1.54186,-0.34009 2.51586,-1.86538 2.17574,-3.40723 l -4.49422,-20.374663 c -0.3401,-1.54187 -1.8655,-2.51637 -3.40736,-2.17627 z m 12.07793,5.47334 c 0.46813,-0.11432 0.96157,0.0321 1.29028,0.38453 l 6.36547,6.81733 c 0.70257,0.75339 0.32031,1.98474 -0.68549,2.20735 l -9.27327,2.04551 c -1.00612,0.2212 -1.87144,-0.735 -1.55103,-1.71404 l 2.9073,-8.86273 c 0.14291,-0.43653 0.50073,-0.76819 0.94674,-0.87795 z m -35.24405,30.41854 c -1.54187,0.34009 -2.51637,1.86549 -2.17625,3.40734 l 4.49424,20.37469 c 0.3401,1.54184 1.866,2.51623 3.40785,2.17613 l 20.37467,-4.49425 c 1.54186,-0.34009 2.51577,-1.86588 2.17564,-3.40775 l -4.49424,-20.37466 c -0.34009,-1.54187 -1.86537,-2.51585 -3.40725,-2.17574 z m 29.64095,-6.53819 c -1.54188,0.34009 -2.51637,1.86549 -2.17624,3.40734 l 4.49422,20.37468 c 0.34009,1.54185 1.86599,2.51624 3.40786,2.17613 l 20.37466,-4.49424 c 1.54186,-0.34008 2.51575,-1.86588 2.17563,-3.40775 l -4.49424,-20.37467 c -0.34009,-1.54186 -1.86537,-2.51584 -3.40724,-2.17573 z m 29.3872,-6.48222 c -1.54188,0.34009 -2.51586,1.86536 -2.17575,3.40723 l 4.49424,20.37466 c 0.3401,1.54188 1.86549,2.51637 3.40736,2.17626 l 20.37467,-4.49423 c 1.54185,-0.3401 2.51625,-1.866 2.17614,-3.40787 l -4.49424,-20.37466 c -0.3401,-1.54187 -1.86589,-2.51575 -3.40774,-2.17564 z m 8.85484,5.43381 c 0.23112,-0.0507 0.47107,-0.0388 0.6961,0.0343 l 8.86276,2.9073 c 0.96099,0.31593 1.23234,1.54611 0.49344,2.237 l -6.81726,6.36598 c -0.75329,0.70511 -1.98747,0.32206 -2.20947,-0.68556 l -2.04494,-9.27077 c -0.15876,-0.72021 0.29855,-1.43232 1.01937,-1.58827 z m -52.85353,11.65896 c 0.72491,-0.17557 1.45273,0.27866 1.61336,1.00703 l 2.04494,9.27076 c 0.22123,1.00614 -0.73498,1.87145 -1.71402,1.55103 l -8.86275,-2.90733 c -0.96101,-0.31594 -1.23224,-1.5456 -0.49333,-2.2365 l 6.81726,-6.36598 c 0.16754,-0.15586 0.37203,-0.26587 0.59454,-0.31902 z m 22.08371,-4.12179 9.27326,-2.0455 c 1.00612,-0.22112 1.87143,0.73498 1.551,1.71402 l -2.90696,8.86424 c -0.31596,0.96099 -1.54608,1.23235 -2.23699,0.49344 l -6.36588,-6.81675 c -0.70508,-0.75327 -0.32208,-1.98746 0.68557,-2.20945 z" />
+  </g>
+</svg>

--- a/index.md
+++ b/index.md
@@ -322,6 +322,12 @@ apps:
           technologies:
             - Python
 
+    complementary_intro: "These applications can further extend your device's functionality, but are not related to OpenRazer."
+    complementary:
+        - name: Input Remapper
+          url: https://github.com/sezanzeb/input-remapper
+          logo: /img/apps/input-remapper.svg
+
 links:
     - label: View Source
       icon: fa-brands fa-github


### PR DESCRIPTION
As suggested in https://github.com/openrazer/openrazer/issues/2399, we could draw more attention to _complementary_ apps that implement features not in scope by OpenRazer, like `input-remapper` via the website.

![Screenshot_20250220_175641](https://github.com/user-attachments/assets/7e8c9059-ee71-42e0-b75d-f8a92dd8a858)
